### PR TITLE
Remove python dependency and add compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,26 @@ This service allows the consumer to search its recipe database for recipes that 
 ## Requirements
 
 - Java 11
-- Python 3.11
-- pip
+- maven
+
+## Giving permission for the maven wrapper
+The maven wrapper is included with this project.  You may need to grant permission to execute this file (or use your own wrapper or mvn directly)
+
+```bash
+chmod u+x mvnw
+```
+
+## Compiling the code
+
+```bash
+./mvnw compile
+```
 
 ## Running the tests
 
+```bash
 ./mvnw test
+```
 
 ## Running the service
 


### PR DESCRIPTION
- The README has a reference to python and pip as a dependency.  There is no python in this codebase, so have removed it.   
- Added maven as a dependency, as some people may not have it installed.
- Have added instructions to chmod the maven wrapper
- Added a command example to compile the code (which should download project dependencies)